### PR TITLE
Switch the link target according to PHP major version

### DIFF
--- a/libexec/phpenv-global
+++ b/libexec/phpenv-global
@@ -43,10 +43,12 @@ fi
 echo ${PHPENV_VERSION}
 
 # Link Apache apxs lib
+rm -f "${PHPENV_ROOT}"/lib/libphp*.so
+LIBPHP_SO_FILE="libphp$(php-config --version | cut -c1).so"
 APXS=""
 if [ "${PHPENV_VERSION}" == "system" ]; then
     DEFAULT_APXS="$(which apxs 2>/dev/null)"
-    if [ -n "${DEFAULT_APXS}" -a -f "$(${DEFAULT_APXS} -q LIBEXECDIR)/libphp5.so" ]; then
+    if [ -n "${DEFAULT_APXS}" -a -f "$(${DEFAULT_APXS} -q LIBEXECDIR)/${LIBPHP_SO_FILE}" ]; then
 	APXS="${DEFAULT_APXS}"
     fi
 fi
@@ -56,6 +58,6 @@ php-config --configure-options 2>/dev/null | grep -q apxs  && \
 [[ -d "${PHPENV_ROOT}/lib" ]] || mkdir "${PHPENV_ROOT}/lib"
 if [ -n "${APXS}" ]; then
     [[ "${PHPENV_VERSION}" == "system" ]] && \
-        ln -fs "$(${APXS} -q LIBEXECDIR)/libphp5.so" "${PHPENV_ROOT}/lib/libphp5.so" || \
-        ln -fs "${PHPENV_ROOT}/versions/${PHPENV_VERSION}/libexec/libphp5.so" "${PHPENV_ROOT}/lib/libphp5.so";
+        ln -fs "$(${APXS} -q LIBEXECDIR)/${LIBPHP_SO_FILE}" "${PHPENV_ROOT}/lib/${LIBPHP_SO_FILE}" || \
+        ln -fs "${PHPENV_ROOT}/versions/${PHPENV_VERSION}/libexec/${LIBPHP_SO_FILE}" "${PHPENV_ROOT}/lib/${LIBPHP_SO_FILE}";
 fi


### PR DESCRIPTION
Apache module name of PHP7 is libphp7.so.  This patch finds PHP major version using 'php-config --version' and set the file name properly.
